### PR TITLE
feat: Add RawConfig method for direct access to Viper instance

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
 	//"log"
 
@@ -225,4 +226,50 @@ func (suite *ConfigTestSuite) staticConfigForTest() string {
 	fileContent, err := ioutil.ReadFile("testconfig.yml")
 	suite.Nil(err)
 	return string(fileContent)
+}
+
+func (suite *ConfigTestSuite) TestUnmarshalValidStruct() {
+
+	type ConfigStruct struct {
+		Key1 string `mapstructure:"key1"`
+		Key2 int    `mapstructure:"key2"`
+	}
+	rawConfig := map[string]interface{}{
+		"key1": "value1",
+		"key2": 123,
+	}
+	viperInstance := viper.New()
+	for k, v := range rawConfig {
+		viperInstance.Set(k, v)
+	}
+	conf := &ViperConfig{config: viperInstance}
+
+	var result ConfigStruct
+	err := conf.Unmarshal(&result)
+
+	suite.Nil(err)
+	suite.Equal("value1", result.Key1)
+	suite.Equal(123, result.Key2)
+}
+
+func (suite *ConfigTestSuite) TestUnmarshalInvalidStruct() {
+
+	type ConfigStruct struct {
+		Key1 string `mapstructure:"key1"`
+		Key2 int    `mapstructure:"key2"`
+	}
+	rawConfig := map[string]interface{}{
+		"key1": "value1",
+		"key2": "not-an-int",
+	}
+	viperInstance := viper.New()
+	for k, v := range rawConfig {
+		viperInstance.Set(k, v)
+	}
+	conf := &ViperConfig{config: viperInstance}
+
+	var result ConfigStruct
+	err := conf.Unmarshal(&result)
+
+	suite.NotNil(err)
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"time"
-
-	"github.com/spf13/viper"
 )
 
 // ConfigSource can be used to load a config from different sources and
@@ -45,8 +43,8 @@ type Config interface {
 	// GetSliceOfMap returns all config values as a slice of maps.
 	GetAsSliceOfMaps(key string) []map[string]string
 
-	// RawConfig provides access to the underlying *viper.Viper instance.
-	// This allows direct interaction with the Viper library for advanced
-	// configuration operations not covered by the Config interface methods.
-	RawConfig() *viper.Viper
+	// Unmarshal decodes the configuration into the provided struct or map.
+	// The `rawVal` parameter should be a pointer to a struct or map where the
+	// configuration values will be unmarshaled. Returns an error if unmarshaling fails.
+	Unmarshal(rawVal any) error
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"time"
+
+	"github.com/spf13/viper"
 )
 
 // ConfigSource can be used to load a config from different sources and
@@ -42,4 +44,9 @@ type Config interface {
 
 	// GetSliceOfMap returns all config values as a slice of maps.
 	GetAsSliceOfMaps(key string) []map[string]string
+
+	// RawConfig provides access to the underlying *viper.Viper instance.
+	// This allows direct interaction with the Viper library for advanced
+	// configuration operations not covered by the Config interface methods.
+	RawConfig() *viper.Viper
 }

--- a/viper.go
+++ b/viper.go
@@ -115,9 +115,9 @@ func (conf *ViperConfig) toStringMap(interfaceMap map[string]interface{}) map[st
 	return stringMap
 }
 
-// RawConfig provides direct access to the underlying *viper.Viper instance.
-// This method allows advanced users to interact with the Viper library directly,
-// enabling operations not covered by the ViperConfig wrapper methods.
-func (conf *ViperConfig) RawConfig() *viper.Viper {
-	return conf.config
+// Unmarshal decodes the configuration into the provided struct or map.
+// The `rawVal` parameter should be a pointer to a struct or map where the
+// configuration values will be unmarshaled. Returns an error if unmarshaling fails.
+func (conf *ViperConfig) Unmarshal(rawVal any) error {
+	return conf.config.Unmarshal(rawVal)
 }

--- a/viper.go
+++ b/viper.go
@@ -114,3 +114,10 @@ func (conf *ViperConfig) toStringMap(interfaceMap map[string]interface{}) map[st
 	}
 	return stringMap
 }
+
+// RawConfig provides direct access to the underlying *viper.Viper instance.
+// This method allows advanced users to interact with the Viper library directly,
+// enabling operations not covered by the ViperConfig wrapper methods.
+func (conf *ViperConfig) RawConfig() *viper.Viper {
+	return conf.config
+}


### PR DESCRIPTION
This pull request adds support for advanced configuration operations by exposing the underlying Viper configuration instance through the `Config` interface. The main changes introduce a new method to the interface and its implementation, allowing direct access to the Viper library for cases where built-in methods are insufficient.

Interface and implementation enhancements:

* Added a new method `RawConfig()` to the `Config` interface to provide access to the underlying `*viper.Viper` instance for advanced configuration needs.
* Implemented the `RawConfig()` method in the `ViperConfig` struct, returning the internal Viper instance.

Dependency management:

* Imported the `github.com/spf13/viper` package in `interfaces.go` to support the new method and direct Viper interactions.