### PR TITLE
fix: pin s3 submodule to published go-config v1.5.0

### DIFF
--- a/s3/go.mod
+++ b/s3/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.43
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.2
 	github.com/stretchr/testify v1.11.1
-	github.com/tommzn/go-config v0.0.0
+	github.com/tommzn/go-config v1.5.0
 )
 
 require (
@@ -43,5 +43,3 @@ require (
 	golang.org/x/text v0.41.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/tommzn/go-config => ../

--- a/s3/go.sum
+++ b/s3/go.sum
@@ -70,6 +70,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/tommzn/go-config v1.5.0 h1:JAdL9ZcMSUn2vLd0HZKZ8NOrlbyxGAv8dvljqqwziEY=
+github.com/tommzn/go-config v1.5.0/go.mod h1:wIkA8D4MBWezTleWYbI4hU/vevspsfLozuznZSCWaJg=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=


### PR DESCRIPTION
## Summary

Follow-up to #10. Removes the `replace github.com/tommzn/go-config => ../` from `s3/go.mod` now that `v1.5.0` (containing `NewConfigFromReader`) is tagged and published, and re-tidies against the real module proxy.

Addresses the last open review thread from #10 (`s3/go.mod:47`, flagged by Copilot): the replace directive would have broken any real external consumer of `github.com/tommzn/go-config/s3`, since replace directives in a dependency's go.mod are ignored by consumers - only the main module's own replace applies.

## Testing
- `go mod tidy` in `s3/` against the real proxy - resolves `github.com/tommzn/go-config v1.5.0` with real checksums, no local replace
- `go build ./...`, `go vet ./...`, `go test ./...` in `s3/` - all pass